### PR TITLE
feat(web): admin login with full error detail; short public messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # Local / runtime files
 /config.yaml
 /config.smoke.yaml
+/config.local.yaml
 *.db
 *.db-journal
 *.db-wal

--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -1,0 +1,216 @@
+// Demo seeder: populates the sqlite store with 90 days of synthetic
+// checks and a handful of realistic-looking incidents so the UI can be
+// driven locally without running real probes.
+//
+// Usage:
+//   go run ./cmd/seed -config config.local.yaml
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"math/rand"
+	"time"
+
+	"github.com/Nobody9512/statuspage/internal/config"
+	"github.com/Nobody9512/statuspage/internal/storage"
+)
+
+type incidentSpec struct {
+	target    string
+	startAgo  time.Duration
+	duration  time.Duration
+	lastError string
+	detail    string
+}
+
+func main() {
+	configPath := flag.String("config", "config.local.yaml", "path to config file")
+	flag.Parse()
+
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		log.Fatalf("config: %v", err)
+	}
+	store, err := storage.Open(cfg.Storage.SQLitePath)
+	if err != nil {
+		log.Fatalf("storage: %v", err)
+	}
+	defer store.Close()
+
+	rng := rand.New(rand.NewSource(42))
+	now := time.Now()
+	start := now.Add(-90 * 24 * time.Hour)
+
+	incidents := defaultIncidents(cfg.Targets, now)
+	incidentByTarget := map[string][]incidentSpec{}
+	for _, inc := range incidents {
+		incidentByTarget[inc.target] = append(incidentByTarget[inc.target], inc)
+	}
+
+	total := 0
+	for _, t := range cfg.Targets {
+		specs := incidentByTarget[t.Name]
+		count, err := seedTarget(store, t.Name, start, now, specs, rng)
+		if err != nil {
+			log.Fatalf("seed %s: %v", t.Name, err)
+		}
+		total += count
+		fmt.Printf("  - %-22s  %5d checks, %d incidents\n", t.Name, count, len(specs))
+	}
+
+	for _, inc := range incidents {
+		if err := openAndMaybeResolve(store, inc, now); err != nil {
+			log.Fatalf("incident %s: %v", inc.target, err)
+		}
+	}
+
+	fmt.Printf("\nSeeded %d checks and %d incidents into %s\n", total, len(incidents), cfg.Storage.SQLitePath)
+	fmt.Println("Start the server with:")
+	fmt.Printf("  go run ./cmd/statuspage -config %s\n", *configPath)
+}
+
+func seedTarget(store *storage.Store, target string, start, now time.Time, specs []incidentSpec, rng *rand.Rand) (int, error) {
+	interval := 15 * time.Minute
+	var batch []storage.Check
+	for ts := start; !ts.After(now); ts = ts.Add(interval) {
+		status := storage.StatusOK
+		errText := ""
+		detail := ""
+		for _, inc := range specs {
+			incStart := now.Add(-inc.startAgo)
+			incEnd := incStart.Add(inc.duration)
+			if !ts.Before(incStart) && ts.Before(incEnd) {
+				status = storage.StatusDown
+				errText = inc.lastError
+				detail = inc.detail
+				break
+			}
+		}
+		latency := int64(80 + rng.Intn(220))
+		if status == storage.StatusDown {
+			latency = int64(1500 + rng.Intn(3000))
+		}
+		batch = append(batch, storage.Check{
+			Target:    target,
+			CheckedAt: ts,
+			Status:    status,
+			LatencyMs: latency,
+			Error:     errText,
+			Detail:    detail,
+		})
+	}
+	if err := store.SaveChecksBulk(batch); err != nil {
+		return 0, err
+	}
+	return len(batch), nil
+}
+
+func openAndMaybeResolve(store *storage.Store, inc incidentSpec, now time.Time) error {
+	startedAt := now.Add(-inc.startAgo)
+	id, err := store.OpenIncident(inc.target, startedAt, inc.lastError)
+	if err != nil {
+		return err
+	}
+	resolvedAt := startedAt.Add(inc.duration)
+	if resolvedAt.Before(now) {
+		if err := store.ResolveIncident(id, resolvedAt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// defaultIncidents builds a set of realistic-looking incidents that mirror
+// the kinds of errors the production checker produces. Only targets that
+// exist in the config get incidents assigned to them.
+func defaultIncidents(targets []config.Target, now time.Time) []incidentSpec {
+	have := map[string]bool{}
+	for _, t := range targets {
+		have[t.Name] = true
+	}
+
+	d := 24 * time.Hour
+	candidates := []incidentSpec{
+		{
+			target:    "EDM e-Invoice",
+			startAgo:  5 * time.Minute,
+			duration:  5 * time.Minute,
+			lastError: `Get "http://127.0.0.1/health/edm": context deadline exceeded`,
+			detail:    "connect tcp 127.0.0.1:80: i/o timeout after 10s",
+		},
+		{
+			target:    "Currency API",
+			startAgo:  2*d + 3*time.Hour,
+			duration:  5 * time.Minute,
+			lastError: `Get "https://ms-price-service.example.com/v1/api/currencies": context deadline exceeded (Client.Timeout exceeded while awaiting headers)`,
+			detail:    "net/http: timeout after 10s reading response headers",
+		},
+		{
+			target:    "EDM e-Invoice",
+			startAgo:  2*d + 15*time.Hour,
+			duration:  1*time.Hour + 53*time.Minute,
+			lastError: "HTTP 503: EDM authentication failed: Session ID not received",
+			detail:    "response body: {\"error\":\"auth-failed\",\"message\":\"Session ID not received\"}",
+		},
+		{
+			target:    "EDM e-Invoice",
+			startAgo:  2*d + 20*time.Hour,
+			duration:  1*time.Hour + 20*time.Minute,
+			lastError: `<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Body><s:Fault><faultcode>s:Server</faultcode><faultstring>internal</faultstring></s:Fault></s:Body></s:Envelope>`,
+			detail:    "SOAP fault returned HTTP 500",
+		},
+		{
+			target:    "Public website",
+			startAgo:  2*d + 20*time.Hour,
+			duration:  1*time.Hour + 20*time.Minute,
+			lastError: "unexpected status 500",
+			detail:    "body: <html><body>Whoops — something went wrong (trace-id: 8c2a...)</body></html>",
+		},
+		{
+			target:    "Internal REST API",
+			startAgo:  2*d + 20*time.Hour,
+			duration:  1*time.Hour + 20*time.Minute,
+			lastError: "unexpected status 403",
+			detail:    `{"error":"forbidden","hint":"token expired"}`,
+		},
+		{
+			target:    "Laravel queue",
+			startAgo:  2*d + 21*time.Hour,
+			duration:  1*time.Hour + 24*time.Minute,
+			lastError: "failed_jobs 5429 > threshold 10",
+			detail:    "reserved older than 15m: 142 rows",
+		},
+		{
+			target:    "Primary Postgres",
+			startAgo:  12 * d,
+			duration:  18 * time.Minute,
+			lastError: `ping: dial tcp 10.0.0.12:5432: connect: connection refused`,
+			detail:    "driver returned: pq: connection refused",
+		},
+		{
+			target:    "Redis",
+			startAgo:  20 * d,
+			duration:  7 * time.Minute,
+			lastError: "dial tcp 10.0.0.15:6379: i/o timeout",
+			detail:    "after 3 retries",
+		},
+		{
+			target:    "SMTP port",
+			startAgo:  40 * d,
+			duration:  2 * time.Hour,
+			lastError: "dial tcp 10.0.0.25:25: connect: connection refused",
+			detail:    "tcp probe",
+		},
+	}
+
+	out := make([]incidentSpec, 0, len(candidates))
+	for _, c := range candidates {
+		if have[c.target] {
+			out = append(out, c)
+		}
+	}
+	_ = now
+	return out
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -6,6 +6,12 @@ server:
     # Leave both empty to disable authentication.
     user: ""
     password: ""
+  admin:
+    # Admin login via /admin/login (Basic auth). When logged in, full
+    # technical error details are shown instead of the short public message.
+    # Leave both empty to disable the admin mode.
+    user: ""
+    password: ""
 
 scheduler:
   interval_minutes: 5

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,9 +22,15 @@ type ServerConfig struct {
 	AutoRefreshSeconds int       `yaml:"auto_refresh_seconds"`
 	BrandName          string    `yaml:"brand_name"`
 	BasicAuth          BasicAuth `yaml:"basic_auth"`
+	Admin              Admin     `yaml:"admin"`
 }
 
 type BasicAuth struct {
+	User     string `yaml:"user"`
+	Password string `yaml:"password"`
+}
+
+type Admin struct {
 	User     string `yaml:"user"`
 	Password string `yaml:"password"`
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -98,6 +98,35 @@ func (s *Store) SaveCheck(c Check) error {
 	return err
 }
 
+// SaveChecksBulk inserts many checks inside a single transaction. Used by
+// the demo seeder; the live checker inserts one row at a time.
+func (s *Store) SaveChecksBulk(checks []Check) error {
+	if len(checks) == 0 {
+		return nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	stmt, err := tx.Prepare(`INSERT INTO checks(target, checked_at, status, latency_ms, error, detail) VALUES (?,?,?,?,?,?)`)
+	if err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	for _, c := range checks {
+		if _, err := stmt.Exec(c.Target, c.CheckedAt.Unix(), string(c.Status), c.LatencyMs, c.Error, c.Detail); err != nil {
+			_ = stmt.Close()
+			_ = tx.Rollback()
+			return err
+		}
+	}
+	if err := stmt.Close(); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	return tx.Commit()
+}
+
 func (s *Store) GetOpenIncident(target string) (*Incident, error) {
 	row := s.db.QueryRow(
 		`SELECT id, target, started_at, resolved_at, last_error, down_email_sent, recovered_email_sent

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1,8 +1,10 @@
 package web
 
 import (
+	"crypto/rand"
 	"crypto/subtle"
 	"embed"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -11,6 +13,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -21,7 +24,12 @@ import (
 //go:embed templates/*.html
 var templatesFS embed.FS
 
-const windowDays = 90
+const (
+	windowDays        = 90
+	adminCookieName   = "sp_admin"
+	adminSessionTTL   = 12 * time.Hour
+	publicErrorText   = "Service disruption detected."
+)
 
 type Server struct {
 	cfg       config.ServerConfig
@@ -31,6 +39,9 @@ type Server struct {
 	store     *storage.Store
 	tmpl      *template.Template
 	lastCycle atomic.Value
+
+	adminMu       sync.Mutex
+	adminSessions map[string]time.Time
 }
 
 func New(cfg config.ServerConfig, refreshSeconds int, targets []config.Target, store *storage.Store) (*Server, error) {
@@ -46,6 +57,7 @@ func New(cfg config.ServerConfig, refreshSeconds int, targets []config.Target, s
 		cfg: cfg, refresh: refreshSeconds,
 		targets: targets, targetMap: tm,
 		store: store, tmpl: tmpl,
+		adminSessions: map[string]time.Time{},
 	}
 	s.lastCycle.Store(time.Time{})
 	return s, nil
@@ -58,6 +70,8 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/", s.handleDashboard)
 	mux.HandleFunc("/service/", s.handleService)
 	mux.HandleFunc("/api/checks/", s.handleAPIChecks)
+	mux.HandleFunc("/admin/login", s.handleAdminLogin)
+	mux.HandleFunc("/admin/logout", s.handleAdminLogout)
 	return s.basicAuth(mux)
 }
 
@@ -78,6 +92,93 @@ func (s *Server) basicAuth(next http.Handler) http.Handler {
 	})
 }
 
+// --- admin auth ---------------------------------------------------
+
+func (s *Server) adminEnabled() bool {
+	return s.cfg.Admin.User != "" && s.cfg.Admin.Password != ""
+}
+
+func (s *Server) isAdmin(r *http.Request) bool {
+	if !s.adminEnabled() {
+		return false
+	}
+	c, err := r.Cookie(adminCookieName)
+	if err != nil || c.Value == "" {
+		return false
+	}
+	s.adminMu.Lock()
+	defer s.adminMu.Unlock()
+	exp, ok := s.adminSessions[c.Value]
+	if !ok {
+		return false
+	}
+	if time.Now().After(exp) {
+		delete(s.adminSessions, c.Value)
+		return false
+	}
+	return true
+}
+
+func (s *Server) newAdminSession() (string, time.Time) {
+	buf := make([]byte, 32)
+	_, _ = rand.Read(buf)
+	token := hex.EncodeToString(buf)
+	exp := time.Now().Add(adminSessionTTL)
+	s.adminMu.Lock()
+	s.adminSessions[token] = exp
+	// opportunistic cleanup
+	now := time.Now()
+	for k, v := range s.adminSessions {
+		if now.After(v) {
+			delete(s.adminSessions, k)
+		}
+	}
+	s.adminMu.Unlock()
+	return token, exp
+}
+
+func (s *Server) handleAdminLogin(w http.ResponseWriter, r *http.Request) {
+	if !s.adminEnabled() {
+		http.Error(w, "Admin mode is not configured.", http.StatusNotFound)
+		return
+	}
+	u, p, ok := r.BasicAuth()
+	if !ok ||
+		subtle.ConstantTimeCompare([]byte(u), []byte(s.cfg.Admin.User)) != 1 ||
+		subtle.ConstantTimeCompare([]byte(p), []byte(s.cfg.Admin.Password)) != 1 {
+		w.Header().Set("WWW-Authenticate", `Basic realm="Statuspage Admin"`)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	token, exp := s.newAdminSession()
+	http.SetCookie(w, &http.Cookie{
+		Name:     adminCookieName,
+		Value:    token,
+		Path:     "/",
+		Expires:  exp,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
+func (s *Server) handleAdminLogout(w http.ResponseWriter, r *http.Request) {
+	if c, err := r.Cookie(adminCookieName); err == nil && c.Value != "" {
+		s.adminMu.Lock()
+		delete(s.adminSessions, c.Value)
+		s.adminMu.Unlock()
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     adminCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
 // --- view models --------------------------------------------------
 
 type dayCell struct {
@@ -88,13 +189,13 @@ type dayCell struct {
 }
 
 type serviceCard struct {
-	Name         string
-	NameEscaped  string
-	StatusClass  string
-	StatusLabel  string
-	BannerClass  string
-	UptimeLabel  string
-	Days         []dayCell
+	Name        string
+	NameEscaped string
+	StatusClass string
+	StatusLabel string
+	BannerClass string
+	UptimeLabel string
+	Days        []dayCell
 }
 
 type incidentEntry struct {
@@ -125,6 +226,7 @@ type dashboardData struct {
 	Banner      banner
 	Services    []serviceCard
 	PastDays    []pastDay
+	IsAdmin     bool
 }
 
 type serviceData struct {
@@ -135,6 +237,7 @@ type serviceData struct {
 	Window      int
 	Service     serviceCard
 	PastDays    []pastDay
+	IsAdmin     bool
 }
 
 // --- handlers -----------------------------------------------------
@@ -144,6 +247,7 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	isAdmin := s.isAdmin(r)
 	now := time.Now()
 	since := now.Add(-windowDays * 24 * time.Hour)
 	since7d := now.Add(-7 * 24 * time.Hour)
@@ -152,7 +256,7 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	anyDown := 0
 	anyWarn := 0
 	for _, t := range s.targets {
-		card := s.buildCard(t, since, now)
+		card := s.buildCard(t, since, now, isAdmin)
 		if card.StatusClass == "down" {
 			anyDown++
 		} else if card.StatusClass == "warn" {
@@ -170,7 +274,7 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 
 	b := computeBanner(anyDown, anyWarn, len(cards))
 
-	past, _ := s.buildPastDays("", since7d, now)
+	past, _ := s.buildPastDays("", since7d, now, isAdmin)
 
 	s.render(w, "dashboard.html", dashboardData{
 		Title:       "Dashboard",
@@ -181,6 +285,7 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 		Banner:      b,
 		Services:    cards,
 		PastDays:    past,
+		IsAdmin:     isAdmin,
 	})
 }
 
@@ -194,11 +299,12 @@ func (s *Server) handleService(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	isAdmin := s.isAdmin(r)
 	now := time.Now()
 	since := now.Add(-windowDays * 24 * time.Hour)
 
-	card := s.buildCard(t, since, now)
-	past, _ := s.buildPastDays(name, since, now)
+	card := s.buildCard(t, since, now, isAdmin)
+	past, _ := s.buildPastDays(name, since, now, isAdmin)
 
 	s.render(w, "service.html", serviceData{
 		Title:       name,
@@ -208,6 +314,7 @@ func (s *Server) handleService(w http.ResponseWriter, r *http.Request) {
 		Window:      windowDays,
 		Service:     card,
 		PastDays:    past,
+		IsAdmin:     isAdmin,
 	})
 }
 
@@ -220,6 +327,7 @@ func (s *Server) handleAPIChecks(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	isAdmin := s.isAdmin(r)
 	days := 7
 	if v := r.URL.Query().Get("days"); v != "" {
 		fmt.Sscanf(v, "%d", &days)
@@ -236,13 +344,21 @@ func (s *Server) handleAPIChecks(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	if !isAdmin {
+		for i := range checks {
+			if checks[i].Status != storage.StatusOK && checks[i].Error != "" {
+				checks[i].Error = publicErrorText
+			}
+			checks[i].Detail = ""
+		}
+	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(checks)
 }
 
 // --- builders -----------------------------------------------------
 
-func (s *Server) buildCard(t config.Target, since, until time.Time) serviceCard {
+func (s *Server) buildCard(t config.Target, since, until time.Time, isAdmin bool) serviceCard {
 	latest, _ := s.store.LatestCheck(t.Name)
 	uptime, total, _ := s.store.UptimePercent(t.Name, since)
 	rollup, _ := s.store.DailyRollup(t.Name, since, until)
@@ -270,7 +386,7 @@ func (s *Server) buildCard(t config.Target, since, until time.Time) serviceCard 
 			cell.Summary = fmt.Sprintf("%d of %d checks failed (%.1f%% down).", r.Down, r.Total, downPct)
 		}
 		if list, ok := incByDay[r.Date.Format("2006-01-02")]; ok && len(list) > 0 {
-			cell.RelatedTitle = incidentTitle(list[0])
+			cell.RelatedTitle = incidentTitle(list[0], isAdmin)
 		}
 		days[i] = cell
 	}
@@ -304,7 +420,7 @@ func (s *Server) buildCard(t config.Target, since, until time.Time) serviceCard 
 	return card
 }
 
-func (s *Server) buildPastDays(target string, since, until time.Time) ([]pastDay, error) {
+func (s *Server) buildPastDays(target string, since, until time.Time, isAdmin bool) ([]pastDay, error) {
 	var incidents []storage.Incident
 	var err error
 	if target == "" {
@@ -327,7 +443,7 @@ func (s *Server) buildPastDays(target string, since, until time.Time) ([]pastDay
 		}
 		if list, ok := byDay[key]; ok {
 			for _, inc := range list {
-				block.Incidents = append(block.Incidents, incidentEntryFrom(inc, target == ""))
+				block.Incidents = append(block.Incidents, incidentEntryFrom(inc, target == "", isAdmin))
 			}
 		}
 		days = append(days, block)
@@ -344,11 +460,11 @@ func groupIncidentsByDay(list []storage.Incident) map[string][]storage.Incident 
 	return out
 }
 
-func incidentEntryFrom(inc storage.Incident, includeTarget bool) incidentEntry {
+func incidentEntryFrom(inc storage.Incident, includeTarget bool, isAdmin bool) incidentEntry {
 	entry := incidentEntry{
-		Title:        incidentTitle(inc),
+		Title:        incidentTitle(inc, isAdmin),
 		Resolved:     inc.ResolvedAt != nil,
-		LastError:    inc.LastError,
+		LastError:    publicIncidentMessage(inc, isAdmin),
 		StartedLabel: inc.StartedAt.UTC().Format("Jan 2, 15:04 UTC"),
 	}
 	if inc.ResolvedAt != nil {
@@ -358,15 +474,25 @@ func incidentEntryFrom(inc storage.Incident, includeTarget bool) incidentEntry {
 	return entry
 }
 
-func incidentTitle(inc storage.Incident) string {
-	if inc.LastError == "" {
-		return fmt.Sprintf("%s outage", inc.Target)
+func incidentTitle(inc storage.Incident, isAdmin bool) string {
+	if isAdmin {
+		if inc.LastError == "" {
+			return fmt.Sprintf("%s outage", inc.Target)
+		}
+		msg := inc.LastError
+		if len(msg) > 80 {
+			msg = msg[:80] + "..."
+		}
+		return fmt.Sprintf("%s: %s", inc.Target, msg)
 	}
-	msg := inc.LastError
-	if len(msg) > 80 {
-		msg = msg[:80] + "..."
+	return fmt.Sprintf("%s — service disruption", inc.Target)
+}
+
+func publicIncidentMessage(inc storage.Incident, isAdmin bool) string {
+	if isAdmin {
+		return inc.LastError
 	}
-	return fmt.Sprintf("%s: %s", inc.Target, msg)
+	return publicErrorText
 }
 
 func computeBanner(down, warn, total int) banner {

--- a/internal/web/templates/dashboard.html
+++ b/internal/web/templates/dashboard.html
@@ -45,6 +45,7 @@
       <div class="title {{ if not .Resolved }}down{{ end }}">{{ .Title }}</div>
       {{ if .Resolved }}
       <div class="line"><span class="tag resolved">Resolved</span> - This incident has been resolved.</div>
+      {{ if and $.IsAdmin .LastError }}<div class="line admin-detail">{{ .LastError }}</div>{{ end }}
       <div class="time">{{ .ResolvedLabel }}</div>
       {{ else }}
       <div class="line"><span class="tag investigating">Investigating</span> - {{ .LastError }}</div>

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -37,6 +37,18 @@
     }
     header.top .meta { font-size: 12px; color: var(--muted); }
     header.top .meta a { color: var(--link); }
+    header.top .meta .admin-tag {
+      display: inline-block;
+      background: var(--ink);
+      color: white;
+      font-size: 10px;
+      font-weight: 600;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      padding: 2px 6px;
+      border-radius: 3px;
+      vertical-align: 2px;
+    }
 
     .banner {
       background: var(--ok);
@@ -163,6 +175,18 @@
     .incident .line .tag.resolved { color: var(--ok); }
     .incident .line .tag.investigating { color: var(--warn); }
     .incident .time { font-size: 12px; color: var(--muted); }
+    .incident .line.admin-detail {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 12px;
+      color: var(--muted);
+      background: #f2f1ec;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 8px 10px;
+      margin-top: 6px;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
 
     .back { font-family: ui-sans-serif, -apple-system, "Segoe UI", sans-serif; font-size: 14px; color: var(--link); text-decoration: none; }
     .back:hover { text-decoration: underline; }
@@ -178,7 +202,7 @@
   <div class="wrap">
     <header class="top">
       <h1>{{ .Brand }}</h1>
-      <div class="meta">Last cycle: {{ .LastCycle }} · <a href="/">Dashboard</a></div>
+      <div class="meta">Last cycle: {{ .LastCycle }} · <a href="/">Dashboard</a>{{ if .IsAdmin }} · <span class="admin-tag">admin</span> · <a href="/admin/logout">logout</a>{{ end }}</div>
     </header>
     {{ template "content" . }}
   </div>

--- a/internal/web/templates/service.html
+++ b/internal/web/templates/service.html
@@ -45,6 +45,7 @@
       <div class="title {{ if not .Resolved }}down{{ end }}">{{ .Title }}</div>
       {{ if .Resolved }}
       <div class="line"><span class="tag resolved">Resolved</span> - This incident has been resolved.</div>
+      {{ if and $.IsAdmin .LastError }}<div class="line admin-detail">{{ .LastError }}</div>{{ end }}
       <div class="time">{{ .ResolvedLabel }}</div>
       {{ else }}
       <div class="line"><span class="tag investigating">Investigating</span> - {{ .LastError }}</div>


### PR DESCRIPTION
## Summary
- Public visitors now see a generic short message (\"service disruption detected\") instead of raw technical error strings in incident feeds, related-day tooltips, and `/api/checks`.
- A new `/admin/login` endpoint authenticates against `server.admin.user` / `server.admin.password` via HTTP Basic and sets a short-lived cookie session; logged-in admins see the full original `LastError` / `Error` / `Detail`.
- `/admin/logout` clears the session. Admin mode is automatically disabled when both admin credentials are empty.

## Config
A new `server.admin` block has been added to `config.example.yaml`:
```yaml
server:
  admin:
    user: \"\"
    password: \"\"
```

## Test plan
- [ ] Start with `server.admin` empty — UI shows \"— service disruption\" titles and generic text; `/admin/login` returns 404.
- [ ] Set `server.admin.user`/`password`, visit `/admin/login`, authenticate via browser Basic prompt, confirm redirect to `/` and the `admin` tag appears in header.
- [ ] Past Incidents and service page now show full technical error text, including for already-resolved incidents.
- [ ] `/api/checks/<name>` returns full `error`/`detail` for admin; generic text and empty `detail` otherwise.
- [ ] `/admin/logout` clears the cookie and public view returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)